### PR TITLE
Date picker update

### DIFF
--- a/main.py
+++ b/main.py
@@ -85,7 +85,6 @@ def export_login_logs(driver):
     )  # this gets us to the Dashboard instead of Portal view
     driver.get("https://schools.clever.com/instant-login/logs")
     time.sleep(5)
-    driver.save_screenshot("export_login_logs1.png")
     export_button = WebDriverWait(driver, 40).until(
         EC.presence_of_element_located(
             (By.XPATH, '//button[@aria-label="Export as .csv"]')


### PR DESCRIPTION
This export has been working consistently for a few days. I'd like to at least submit this for review so that it's ready to go once Clever can confirm, as long as they don't change the behavior.

Basically they added a date picker popup after you click download, so now we can only download one day of data at a time. This script gets "yesterday's" data, and now becomes one of the jobs we need to keep an eye on if it fails one day or another.

Ideally we would add a backfill option where it can download multiple previous days... but I think that should be a separate PR.